### PR TITLE
Fix overzealous substitution of root folder

### DIFF
--- a/gcovr/__main__.py
+++ b/gcovr/__main__.py
@@ -241,7 +241,7 @@ def main(args=None):
 
     # The root filter isn't technically a filter,
     # but is used to turn absolute paths into relative paths
-    options.root_filter = re.compile(re.escape(options.root_dir + os.sep))
+    options.root_filter = re.compile('^' + re.escape(options.root_dir + os.sep))
 
     if options.exclude_dirs is not None:
         options.exclude_dirs = [


### PR DESCRIPTION
If the root folder occurs somewhere in the file name, it is replaced by the empty string by `root_filter.sub('', filename)`, resulting in an invalid file name. Consider for example the transformation
```
/src/libs/libjhtml/src/libjhtml/DataUri.cc -> libs/libjhtmllibjhtml/DataUri.cc
```
when `--root /src` is given.

This PR fixes the problem by only substituting the root folder at the start of the file name.